### PR TITLE
Fix releases page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ myCodec.decode(bitVector).toDisjunction
 Getting Binaries
 ----------------
 
-See the [releases page on the website](https://scodec.org/releases/).
+See the [releases page on the website](http://scodec.org/releases/).
 
 Administrative
 --------------


### PR DESCRIPTION
It had an `https` link, but only `http` appears to work.
